### PR TITLE
feat: Add file size validation to upload endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -92,6 +92,17 @@ def validate_video_file(file: UploadFile) -> None:
     # ファイルサイズチェック（10MB）
     max_size = 10 * 1024 * 1024  # 10MB
     
+    # ファイルの内容を読み取らずにサイズを取得
+    file.file.seek(0, 2)
+    file_size = file.file.tell()
+    file.file.seek(0)
+
+    if file_size > max_size:
+        raise HTTPException(
+            status_code=413,  # Payload Too Large
+            detail=f"File size ({file_size / 1024 / 1024:.2f}MB) exceeds the limit of {max_size / 1024 / 1024}MB."
+        )
+
     # Content-Typeチェック
     allowed_types = ["video/mp4", "video/mpeg", "video/quicktime"]
     if file.content_type not in allowed_types:


### PR DESCRIPTION
The `liveness/check` endpoint did not validate the size of the uploaded video file. This could lead to excessive resource consumption if a large file is uploaded.

This change adds a validation check to the `validate_video_file` function to ensure that the uploaded file size does not exceed the 10MB limit specified in the API documentation.

The file size is checked by seeking to the end of the file object, which is an efficient way to get the size without reading the entire file into memory. If the file is too large, the API now returns a 413 Payload Too Large error.