### PR TITLE
Fix: Cast numpy types to Python types for JSON serialization

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -109,11 +109,11 @@ class FallbackPassiveChecker:
                 scores.append(0.5)  # デフォルトスコア
         
         average_score = sum(scores) / len(scores) if scores else 0.5
-        passed = average_score >= self.threshold
+        passed = bool(average_score >= self.threshold)
         
         return {
             "passed": passed,
-            "average_real_score": round(average_score, 3),
+            "average_real_score": round(float(average_score), 3),
             "message": "Fallback passive check (basic image quality analysis)"
         }
 


### PR DESCRIPTION
In the `FallbackPassiveChecker`, the `check` method was returning a dictionary containing values with numpy data types (`numpy.bool_` and `numpy.float64`).

The default JSON encoder cannot serialize these numpy-specific types, which caused a `TypeError: Object of type bool is not JSON serializable` when the API tried to return a response.

This commit fixes the issue by explicitly casting the numpy boolean to a standard Python `bool` and the numpy float to a standard Python `float` before returning the dictionary. This ensures that the response data is always JSON serializable.